### PR TITLE
Fetch all SSM parameters for a given path, following NextToken.

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -13,8 +13,9 @@
   [['org.clojure/clojure clj-version :scope "provided"]])
 
 (def ssm-deps
-  '[[com.amazonaws/aws-java-sdk-core "1.11.476"]
-    [com.amazonaws/aws-java-sdk-ssm "1.11.476"]])
+  '[[com.cognitect.aws/api "0.8.289"
+     com.cognitect.aws/endpoints "1.1.11.526"
+     com.cognitect.aws/ssm "712.2.414.0"]])
 
 (def dev-deps
   '[[boot/core "2.8.2" :scope "provided"]


### PR DESCRIPTION
Also replace Java AWS SDK with Cognitect's AWS client.

Without following NextToken and recursively fetching, SSM will return a maximum of 10 parameters, regardless of how many leaves are in the path.