### PR TITLE
Fix warning with Clojure 1.11

### DIFF
--- a/src/omniconf/core.clj
+++ b/src/omniconf/core.clj
@@ -8,7 +8,7 @@
 
 (ns omniconf.core
   "Omniconf is an exhaustive configuration tool."
-  (:refer-clojure :exclude [get set *data-readers*])
+  (:refer-clojure :exclude [get set parse-boolean *data-readers*])
   (:require [clojure.core :as clj]
             [clojure.edn :as edn]
             [clojure.java.io :as io]


### PR DESCRIPTION
Building under Clojure 1.11.1 produces the following warning:
```
WARNING: parse-boolean already refers to: #'clojure.core/parse-boolean in namespace: omniconf.core, being replaced by: #'omniconf.core/parse-boolean
```