### PR TITLE
Fixes EKS bug wrt ServiceAccounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### 0.5.0-SNAPSHOT (unreleased)
 
 - Add ability to unset values from SSM.
+- Fixes bug where `populate-from-ssm` would assume node role instead of pod role
+  when running in EKS.
 
 ### 0.4.3 (2021-03-29)
 

--- a/deps.edn
+++ b/deps.edn
@@ -10,6 +10,7 @@
           :ns-aliases {bb org.corfield.build}}
 
   :ssm {:extra-deps {com.amazonaws/aws-java-sdk-core {:mvn/version "1.12.566"}
+                     com.amazonaws/aws-java-sdk-sts {:mvn/version "1.12.566"}
                      com.amazonaws/aws-java-sdk-ssm {:mvn/version "1.12.566"}}}
   :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
   :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0-alpha4"}}}


### PR DESCRIPTION
This change fixes a critical bug when running on EKS, in which omniconf assumes the node role instead of ServiceAccount's pod role. 

I.e: this change adds `aws-java-sdk-sts` dependency, allowing omniconf to read information from `AWS_WEB_IDENTITY_TOKEN_FILE`.